### PR TITLE
allow network policies to be used on provider

### DIFF
--- a/charts/akash-provider/Chart.yaml
+++ b/charts/akash-provider/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.135.0
+version: 0.136.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/akash-provider/templates/configmap-boot.yaml
+++ b/charts/akash-provider/templates/configmap-boot.yaml
@@ -65,5 +65,5 @@ data:
     ##
     # Run daemon
     ##
-    /bin/akash --home="$AKASH_HOME" --node="$AKASH_NODE" --chain-id="$AKASH_CHAIN_ID" --keyring-backend="$AKASH_KEYRING_BACKEND" --from="$AKASH_FROM" provider run --cluster-k8s --deployment-network-policies-enabled false || exit 1
+    /bin/akash --home="$AKASH_HOME" --node="$AKASH_NODE" --chain-id="$AKASH_CHAIN_ID" --keyring-backend="$AKASH_KEYRING_BACKEND" --from="$AKASH_FROM" provider run --cluster-k8s --deployment-network-policies-enabled $DEPLOYMENT_NETWORK_POLICIES_ENABLED || exit 1
     if $AKASH_DEBUG == "true"; then sleep 5000; fi

--- a/charts/akash-provider/templates/deployment.yaml
+++ b/charts/akash-provider/templates/deployment.yaml
@@ -89,6 +89,9 @@ spec:
             - name: AKASH_DEPLOYMENT_INGRESS_DOMAIN
               value: "ingress.{{ .Values.domain }}"
 
+            - name: deploymentnetworkpoliciesenabled
+              value: "{{ .Values.deploymentnetworkpoliciesenabled }}"
+
             - name: AKASH_YES
               value: "true"
 

--- a/charts/akash-provider/values.yaml
+++ b/charts/akash-provider/values.yaml
@@ -51,6 +51,8 @@ bidpriceendpointscale: "0"
 bidpricestoragescale: "0.00016"
 withdrawalperiod: "24h"
 
+deploymentnetworkpoliciesenabled: "false"
+
 attributes:
   - key: region
     value: us-west


### PR DESCRIPTION
This is required to troubleshoot DNS issues on the testnet clusters. The default has stayed the same so it shouldn't effect anyone.