### PR TITLE
Enable prometheus metrics on nginx ingress controller

### DIFF
--- a/charts/akash-ingress/Chart.yaml
+++ b/charts/akash-ingress/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/akash-ingress/Chart.yaml
+++ b/charts/akash-ingress/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/akash-ingress/Chart.yaml
+++ b/charts/akash-ingress/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 1.0.0
+appVersion: 1.5.1

--- a/charts/akash-ingress/templates/controller-daemonset.yaml
+++ b/charts/akash-ingress/templates/controller-daemonset.yaml
@@ -23,6 +23,12 @@ spec:
   minReadySeconds: 0
   template:
     metadata:
+    {{- if .Values.controller.podAnnotations }}
+      annotations:
+      {{- range $key, $value := .Values.controller.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+    {{- end }}
       labels:
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/instance: ingress-nginx
@@ -31,7 +37,7 @@ spec:
       dnsPolicy: ClusterFirst
       containers:
         - name: controller
-          image: k8s.gcr.io/ingress-nginx/controller:v1.0.0@sha256:0851b34f69f69352bf168e6ccf30e1e20714a264ab1ecd1933e4d8c0fc3215c6
+          image: k8s.gcr.io/ingress-nginx/controller:v1.5.1@sha256:4ba73c697770664c1e00e9f968de14e08f606ff961c76e5d7033a4a9c593c629
           imagePullPolicy: IfNotPresent
           lifecycle:
             preStop:
@@ -48,6 +54,7 @@ spec:
             - --validating-webhook-certificate=/usr/local/certificates/cert
             - --validating-webhook-key=/usr/local/certificates/key
             - --enable-ssl-passthrough
+            - --enable-metrics
           securityContext:
             capabilities:
               drop:
@@ -152,6 +159,11 @@ spec:
               containerPort: 26664
               protocol: TCP
               hostPort: 26664
+            {{- end }}
+            {{- if .Values.controller.metrics.enabled }}
+            - name: {{ .Values.controller.metrics.portName }}
+              containerPort: {{ .Values.controller.metrics.port }}
+              protocol: TCP
             {{- end }}
           volumeMounts:
             - name: webhook-cert

--- a/charts/akash-ingress/templates/ingress-metrics.yaml
+++ b/charts/akash-ingress/templates/ingress-metrics.yaml
@@ -1,0 +1,41 @@
+
+{{- if .Values.controller.metrics.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+{{- if .Values.controller.metrics.service.annotations }}
+  annotations: {{ toYaml .Values.controller.metrics.service.annotations | nindent 4 }}
+{{- end }}
+  labels:
+    app.kubernetes.io/component: controller
+  {{- if .Values.controller.metrics.service.labels }}
+    {{- toYaml .Values.controller.metrics.service.labels | nindent 4 }}
+  {{- end }}
+  name: ingress-nginx-controller-metrics
+  namespace: ingress-nginx
+spec:
+  type: {{ .Values.controller.metrics.service.type }}
+{{- if .Values.controller.metrics.service.clusterIP }}
+  clusterIP: {{ .Values.controller.metrics.service.clusterIP }}
+{{- end }}
+{{- if .Values.controller.metrics.service.externalIPs }}
+  externalIPs: {{ toYaml .Values.controller.metrics.service.externalIPs | nindent 4 }}
+{{- end }}
+{{- if .Values.controller.metrics.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.controller.metrics.service.loadBalancerIP }}
+{{- end }}
+{{- if .Values.controller.metrics.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{ toYaml .Values.controller.metrics.service.loadBalancerSourceRanges | nindent 4 }}
+{{- end }}
+  ports:
+    - name: {{ .Values.controller.metrics.portName }}
+      port: {{ .Values.controller.metrics.service.servicePort }}
+      protocol: TCP
+      targetPort: {{ .Values.controller.metrics.portName }}
+    {{- $setNodePorts := (or (eq .Values.controller.metrics.service.type "NodePort") (eq .Values.controller.metrics.service.type "LoadBalancer")) }}
+    {{- if (and $setNodePorts (not (empty .Values.controller.metrics.service.nodePort))) }}
+      nodePort: {{ .Values.controller.metrics.service.nodePort }}
+    {{- end }}
+  selector:
+    app.kubernetes.io/component: controller
+{{- end }}

--- a/charts/akash-ingress/values.yaml
+++ b/charts/akash-ingress/values.yaml
@@ -21,3 +21,22 @@ faucet:
 # Used for Testnet networks (ignore)
 bootstrap:
   enabled: false
+
+controller:
+  metrics:
+    port: 10254
+    portName: metrics
+    enabled: false
+
+    service:
+      annotations: {}
+      # prometheus.io/scrape: "true"
+      # prometheus.io/port: "10254"
+
+      externalIPs: []
+
+      # loadBalancerIP: ""
+      loadBalancerSourceRanges: []
+      servicePort: 10254
+      type: ClusterIP
+      # nodePort: ""


### PR DESCRIPTION
This PR makes it possible for providers to enable Prometheus metrics on their Akash nginx ingress controller. **It is disabled by default so that new upgrades do not break existing installations in case the helm chart version is updated**

This screenshot shows a Grafana dashboard on a freshly installed Akash ingress with Prometheus metrics enabled.

<img width="1360" alt="image" src="https://user-images.githubusercontent.com/7607329/209590622-1a4fc820-aff5-4561-a2b5-b3c109f14b06.png">

To upgrade the chart and enable metrics run:
```bash
helm upgrade akash-ingress <chart> -n ingress-nginx -f ./values.yaml --set controller.metrics.enabled=true \
--set-string controller.podAnnotations."prometheus\.io/scrape"="true" \
--set-string controller.podAnnotations."prometheus\.io/port"="10254"
```

To quickly install Prometheus and test the metrics run:
```bash
kubectl apply --kustomize github.com/kubernetes/ingress-nginx/deploy/prometheus/
```

**This PR also updates the nginx ingress controller version to v1.5.1**