### PR TITLE
fix(provider): Remove redundant service labels

### DIFF
--- a/charts/akash-provider/templates/service.yaml
+++ b/charts/akash-provider/templates/service.yaml
@@ -5,8 +5,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     akash.network: "true"
-    app.kubernetes.io/name: akash
-    app.kubernetes.io/instance: inventory
     app.kubernetes.io/component: operator
     {{- include "provider.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
This fixes the following Helm error.

```
Error: map[string]interface {}(nil): yaml: unmarshal errors: line 13: mapping key "app.kubernetes.io/name" already defined at line 9 line 14: mapping key "app.kubernetes.io/instance" already defined at line 10
```