### PR TITLE
feat: update provider to v0.6.5

### DIFF
--- a/charts/akash-hostname-operator/Chart.yaml
+++ b/charts/akash-hostname-operator/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
 # Major version bit highlights the mainnet release (e.g. mainnet4 = 4.x.x, mainnet5 = 5.x.x, ...)
-version: 11.1.0
+version: 11.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,4 +25,4 @@ version: 11.1.0
 # It is recommended to use it with quotes.
 #
 # Refs https://github.com/akash-network/provider/releases
-appVersion: 0.6.4
+appVersion: 0.6.5

--- a/charts/akash-inventory-operator/Chart.yaml
+++ b/charts/akash-inventory-operator/Chart.yaml
@@ -17,11 +17,11 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
 # Major version bit highlights the mainnet release (e.g. mainnet4 = 4.x.x, mainnet5 = 5.x.x, ...)
-version: 11.1.0
+version: 11.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 #
 # Refs https://github.com/akash-network/provider/releases
-appVersion: 0.6.4
+appVersion: 0.6.5

--- a/charts/akash-ip-operator/Chart.yaml
+++ b/charts/akash-ip-operator/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
 # Major version bit highlights the mainnet release (e.g. mainnet4 = 4.x.x, mainnet5 = 5.x.x, ...)
-version: 11.1.0
+version: 11.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,4 +25,4 @@ version: 11.1.0
 # It is recommended to use it with quotes.
 #
 # Refs https://github.com/akash-network/provider/releases
-appVersion: 0.6.4
+appVersion: 0.6.5

--- a/charts/akash-provider/Chart.yaml
+++ b/charts/akash-provider/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
 # Major version bit highlights the mainnet release (e.g. mainnet4 = 4.x.x, mainnet5 = 5.x.x, ...)
-version: 11.2.1
+version: 11.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/akash-provider/Chart.yaml
+++ b/charts/akash-provider/Chart.yaml
@@ -17,11 +17,11 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
 # Major version bit highlights the mainnet release (e.g. mainnet4 = 4.x.x, mainnet5 = 5.x.x, ...)
-version: 11.1.2
+version: 11.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 #
 # Refs https://github.com/akash-network/provider/releases
-appVersion: 0.6.4
+appVersion: 0.6.5

--- a/charts/akash-provider/scripts/run.sh
+++ b/charts/akash-provider/scripts/run.sh
@@ -19,11 +19,5 @@ type bc || exit 1
 ##
 /scripts/refresh_provider_cert.sh
 
-# Start provider-services and monitor its output
-exec provider-services run | while read line; do
-    echo "$line"
-    if [[ "$line" == *"account sequence mismatch"* ]]; then
-        echo "Pattern 'account sequence mismatch' found. Restarting provider-services..."
-        exit 2
-    fi
-done
+# Start provider-services
+exec provider-services run


### PR DESCRIPTION
# Do not merge until provider-services v0.6.5 is cut and released

Updated charts to provider-services v0.6.5

Removes account sequence mismatch check