### PR TITLE
fix: add check for empty nodes

### DIFF
--- a/charts/akash-inventory-operator/Chart.yaml
+++ b/charts/akash-inventory-operator/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
 # Major version bit highlights the mainnet release (e.g. mainnet4 = 4.x.x, mainnet5 = 5.x.x, ...)
-version: 11.6.2
+version: 11.6.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/akash-inventory-operator/templates/configmap-gpucheck.yaml
+++ b/charts/akash-inventory-operator/templates/configmap-gpucheck.yaml
@@ -10,6 +10,15 @@ data:
     echo "$(date): Running inventory liveness check..."
     INVENTORY=$(curl -sSf http://127.0.0.1:8080/v1/inventory)
 
+    # Check for empty nodes
+    TOTAL_NODES=$(echo "$INVENTORY" | jq '.nodes | length')
+    if [ "$TOTAL_NODES" -eq 0 ]; then
+      echo "ERROR: No nodes detected in inventory - operator-inventory likely lost K8s API connectivity"
+      echo "$(date): Liveness check failed - empty nodes array detected"
+      exit 1
+    fi
+    echo "Found $TOTAL_NODES total nodes in inventory"
+
     echo "Checking for nodes with GPU capacity..."
     GPU_NODES=$(echo "$INVENTORY" | jq -c '.nodes[] | select(.resources.gpu.quantity.capacity != "0")' | wc -l)
 


### PR DESCRIPTION
Operator inventory is reporting the below when it fails to connect to the Kubernetes API server - the pod has to be bounced manually to recover

```
root@vignesh-test:~# kubectl -n akash-services exec -ti deploy/operator-inventory -- bash
root@operator-inventory-fdbfff5f4-q8f8x:/# curl -sSf http://127.0.0.1:8080/v1/inventory
{"nodes":[],"storage":[]}
```

#### Testing
Deployed this fix using the helm upgrade and bounced the pods and I also restarted k3s service now to reproduce the issue


```
root@vignesh-test:~/helm-charts/charts# kubectl exec -it operator-inventory-7b447dfdd-64wpp -n akash-services -- bash
root@operator-inventory-7b447dfdd-64wpp:/# INVENTORY=$(curl -sSf http://127.0.0.1:8080/v1/inventory)
root@operator-inventory-7b447dfdd-64wpp:/# TOTAL_NODES=$(echo "$INVENTORY" | jq '.nodes | length')
root@operator-inventory-7b447dfdd-64wpp:/# echo $TOTAL_NODES
0
root@operator-inventory-7b447dfdd-64wpp:/# exit
exit
command terminated with exit code 127
```
##### waiting for the liveness probe to take effect
```
root@vignesh-test:~/helm-charts/charts# kubectl get pods -n akash-services
NAME                                                  READY   STATUS             RESTARTS       AGE
akash-provider-0                                      0/1     Init:0/1           0              62m
operator-hostname-5bc89759b8-2pmr5                    1/1     Running            0              65m
operator-inventory-7b447dfdd-64wpp                    1/1     Running            0              2m32s
```
##### after a couple of minutes..
```
root@vignesh-test:~/helm-charts/charts# kubectl get pods -n akash-services
NAME                                                  READY   STATUS             RESTARTS         AGE
akash-provider-0                                      0/1     Init:0/1           0                66m
operator-hostname-5bc89759b8-2pmr5                    1/1     Running            0                69m
operator-inventory-7b447dfdd-64wpp                    1/1     Running            1 (2m26s ago)    6m29s
operator-inventory-hardware-discovery-34.60.117.188   1/1     Running            0                2m25s
```

```
root@vignesh-test:~/helm-charts/charts# kubectl describe pod operator-inventory-7b447dfdd-64wpp -n akash-services
  Type     Reason     Age    From               Message
  ----     ------     ----   ----               -------
  Normal   Scheduled  6m48s  default-scheduler  Successfully assigned akash-services/operator-inventory-7b447dfdd-64wpp to 34.60.117.188
  Normal   Pulled     6m47s  kubelet            Container image "ghcr.io/akash-network/provider:0.6.11-rc1" already present on machine
  Normal   Created    6m47s  kubelet            Created container: operator-inventory
  Normal   Started    6m47s  kubelet            Started container operator-inventory
  Warning  Unhealthy  2m46s  kubelet            Liveness probe failed: Sun Jun 15 05:29:54 UTC 2025: Running inventory liveness check...
ERROR: No nodes detected in inventory - operator-inventory likely lost K8s API connectivity
Sun Jun 15 05:29:54 UTC 2025: Liveness check failed - empty nodes array detected
  Normal  Killing  2m46s  kubelet  Container operator-inventory failed liveness probe, will be restarted
```