### PR TITLE
feat: adds nodejs-app standard config to console-api

### DIFF
--- a/charts/console-api/Chart.lock
+++ b/charts/console-api/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: nodejs-app
+  repository: file://../nodejs-app
+  version: 0.1.1
+digest: sha256:7d5177f8b768103a89646a16575d598973b0d602af0657e4e12332a6ba04a6c3
+generated: "2025-06-19T07:35:07.315362+03:00"

--- a/charts/console-api/Chart.yaml
+++ b/charts/console-api/Chart.yaml
@@ -14,9 +14,14 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.5.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "2.82.0"
+
+dependencies:
+  - name: nodejs-app
+    version: 0.1.1
+    repository: "file://../nodejs-app"

--- a/charts/console-api/templates/configmap.yaml
+++ b/charts/console-api/templates/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Chart.Name }}-{{ .Values.chain }}-config
+data:
+{{ include "app.env" . | indent 2 }}

--- a/charts/console-api/templates/deployment.yaml
+++ b/charts/console-api/templates/deployment.yaml
@@ -28,13 +28,18 @@ spec:
             - containerPort: 3000
               name: api-port
               protocol: TCP
+          envFrom:
+            - secretRef:
+                name: {{ .Chart.Name }}-{{ .Values.chain }}-secret
+            - configMapRef:
+                name: {{ .Chart.Name }}-{{ .Values.chain }}-config
           env:
             - name: PORT
               value: "3000"
-            - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "namespace={{ .Release.Namespace }}"
             - name: OTEL_SERVICE_NAME
               value: {{ .Chart.Name }}-{{ .Values.chain }}
+            - name: NETWORK
+              value: {{ .Values.chain }}
           resources:
             limits:
               cpu: "1"
@@ -56,6 +61,3 @@ spec:
               port: 3000
             initialDelaySeconds: 5
             periodSeconds: 10
-          envFrom:
-            - secretRef:
-                name: {{ .Chart.Name }}-{{ .Values.chain }}-secret


### PR DESCRIPTION
## Why

console-api doesn't use source-maps and don't ignore network selection type. We need this for easier debugging and to get rid of fetch timeout issues

## What

dds nodejs-app standard config to console-api