### PR TITLE
feat: higher failureThreshold for console-api and live/ready probes for provider-proxy

### DIFF
--- a/charts/console-api/Chart.yaml
+++ b/charts/console-api/Chart.yaml
@@ -14,12 +14,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.1
+version: 0.5.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.82.0"
+appVersion: "2.107.2"
 
 dependencies:
   - name: nodejs-app

--- a/charts/console-api/templates/deployment.yaml
+++ b/charts/console-api/templates/deployment.yaml
@@ -55,9 +55,13 @@ spec:
               port: 3000
             initialDelaySeconds: 5
             periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
           livenessProbe:
             httpGet:
               path: /v1/healthz/liveness
               port: 3000
             initialDelaySeconds: 5
             periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3

--- a/charts/provider-proxy/Chart.yaml
+++ b/charts/provider-proxy/Chart.yaml
@@ -14,12 +14,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.2
+version: 0.4.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.4.3"
+appVersion: "1.13.3"
 
 dependencies:
   - name: nodejs-app

--- a/charts/provider-proxy/templates/deployment.yaml
+++ b/charts/provider-proxy/templates/deployment.yaml
@@ -42,3 +42,19 @@ spec:
               cpu: "0.25"
               ephemeral-storage: "1Gi"
               memory: "256Mi"
+          readinessProbe:
+            httpGet:
+              path: /status
+              port: 3000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 1
+          livenessProbe:
+            httpGet:
+              path: /status
+              port: 3000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 1


### PR DESCRIPTION
## Why

Recently console-api was restarted many times due to liveness probe failure. That's why increasing failureThreshold to ensure it doesn't restart in case if db is slow. 

Provider proxy didn't have live/ready probes at all what allowed us to promote container with a bug