### PR TITLE
fix: name of schema for pgboss in console-api-bg-jobs

### DIFF
--- a/charts/console-api/Chart.yaml
+++ b/charts/console-api/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.0
+version: 0.7.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/console-api/templates/deployment-bg-jobs.yaml
+++ b/charts/console-api/templates/deployment-bg-jobs.yaml
@@ -43,7 +43,7 @@ spec:
             - name: INTERFACE
               value: "background-jobs"
             - name: POSTGRES_BACKGROUND_JOBS_SCHEMA
-              value: pgboss-{{ .Values.chain }}
+              value: pgboss_{{ .Values.chain }}
           resources:
             limits:
               cpu: "0.5"


### PR DESCRIPTION
## Why

pgboss requires names to match `\W` regexp