### PR TITLE
fix: sets proper pgboss name for console-api instance

### DIFF
--- a/charts/console-api/Chart.yaml
+++ b/charts/console-api/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.1
+version: 0.7.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/console-api/templates/deployment.yaml
+++ b/charts/console-api/templates/deployment.yaml
@@ -42,6 +42,8 @@ spec:
               value: {{ .Values.chain }}
             - name: INTERFACE
               value: "rest"
+            - name: POSTGRES_BACKGROUND_JOBS_SCHEMA
+              value: pgboss_{{ .Values.chain }}
           resources:
             limits:
               cpu: "4"


### PR DESCRIPTION
## Why

console-api and console-api-bg-jobs must point to the same pg schema