### PR TITLE
fix: ensure that cronjobs uses the proper pgboss db schema

### DIFF
--- a/charts/console-api/Chart.yaml
+++ b/charts/console-api/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.2
+version: 0.7.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/console-api/templates/jobs.yaml
+++ b/charts/console-api/templates/jobs.yaml
@@ -32,4 +32,7 @@ spec:
               envFrom:
                 - secretRef:
                     name: {{ $.Chart.Name }}-{{ $.Values.chain }}-secret
+              env:
+                - name: POSTGRES_BACKGROUND_JOBS_SCHEMA
+                  value: pgboss_{{ $.Values.chain }}
 {{- end }}


### PR DESCRIPTION
## Why

currently cronjobs create another pgboss schema which is called `pgboss` but instead should use one based on chain network: pgboss_mainnet or pgboss_sandbox