### PR TITLE
feat(akash-provider): allow provider to be run in debug mode

### DIFF
--- a/charts/akash-provider/scripts/run.sh
+++ b/charts/akash-provider/scripts/run.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+run_debug=${AKASH_DEBUG:-false}
+dlv_port=${AKASH_DEBUG_DELVE_PORT:-2345}
+
 # fail fast should these packages be missing
 type curl || exit 1
 type jq || exit 1
@@ -17,20 +20,20 @@ type bc || exit 1
 /scripts/refresh_provider_cert.sh
 
 # Build provider-services run command with optional certificate issuer flags
-PROVIDER_CMD="provider-services run"
+PROVIDER_CMD="/usr/bin/provider-services run"
 
 # Add certificate issuer flags if enabled
 if [[ "${AP_CERT_ISSUER_ENABLED}" == "true" ]]; then
     PROVIDER_CMD="${PROVIDER_CMD} --cert-issuer-enabled=true"
-    
+
     if [[ -n "${AP_CERT_ISSUER_DNS_PROVIDERS}" ]]; then
         PROVIDER_CMD="${PROVIDER_CMD} --cert-issuer-dns-providers=${AP_CERT_ISSUER_DNS_PROVIDERS}"
     fi
-    
+
     if [[ -n "${AP_CERT_ISSUER_EMAIL}" ]]; then
         PROVIDER_CMD="${PROVIDER_CMD} --cert-issuer-email=${AP_CERT_ISSUER_EMAIL}"
     fi
-    
+
     if [[ -n "${AP_CERT_ISSUER_CA_DIR_URL}" ]]; then
         PROVIDER_CMD="${PROVIDER_CMD} --cert-issuer-ca-dir-url=${AP_CERT_ISSUER_CA_DIR_URL}"
     fi
@@ -46,4 +49,14 @@ echo "Final command: ${PROVIDER_CMD}"
 echo "=============================="
 
 # Start provider-services and monitor its output
-${PROVIDER_CMD}
+runcmd=${PROVIDER_CMD}
+
+if [[ $run_debug == true ]]; then
+    if command /go/bin/dlv; then
+        runcmd="/go/bin/dlv --listen=:${dlv_port} --headless=true --api-version=2 --log exec ${PROVIDER_CMD}"
+    else
+        echo "AKASH_DEBUG is set, but no dlv is present in the image. check if docker image has debug suffix"
+    fi
+fi
+
+${runcmd}


### PR DESCRIPTION
debug mode uses docker images with -debug suffix
set env AKASH_DEBUG=true to start provider service in debug mode. **note**, service itself does not start until debug session is attached. default debug port is 2345. Port can be changed via AKASH_DEBUG_DELVE_PORT.

to attach to debugger proxy port to localhost using kubectl. refer to provider services documentation for detailed instructions.