### PR TITLE
chore: bump versions

### DIFF
--- a/charts/akash-node/Chart.yaml
+++ b/charts/akash-node/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
 # Major version bit highlights the mainnet release (e.g. mainnet4 = 4.x.x, mainnet5 = 5.x.x, ...)
-version: 12.1.2
+version: 12.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -26,4 +26,4 @@ version: 12.1.2
 # Refs
 # https://github.com/akash-network/node/releases
 # https://github.com/akash-network/net/blob/main/mainnet/version.txt
-appVersion: 0.38.5
+appVersion: 0.38.2


### PR DESCRIPTION
Go back to 0.38.2 for JWT upgrade