### PR TITLE
fix: adds DEPLOYMENT_ENV env var to console services

### DIFF
--- a/charts/console-api/Chart.yaml
+++ b/charts/console-api/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.6
+version: 0.7.7
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/console-api/templates/configmap.yaml
+++ b/charts/console-api/templates/configmap.yaml
@@ -4,3 +4,11 @@ metadata:
   name: {{ .Chart.Name }}-{{ .Values.chain }}-config
 data:
 {{ include "app.env" . | indent 2 }}
+  - name: PORT
+    value: "3000"
+  - name: NETWORK
+    value: {{ .Values.chain }}
+  - name: DEPLOYMENT_ENV
+    value: {{ .Values.deploymentEnv }}
+  - name: POSTGRES_BACKGROUND_JOBS_SCHEMA
+    value: pgboss_{{ .Values.chain }}

--- a/charts/console-api/templates/configmap.yaml
+++ b/charts/console-api/templates/configmap.yaml
@@ -4,11 +4,7 @@ metadata:
   name: {{ .Chart.Name }}-{{ .Values.chain }}-config
 data:
 {{ include "app.env" . | indent 2 }}
-  - name: PORT
-    value: "3000"
-  - name: NETWORK
-    value: {{ .Values.chain }}
-  - name: DEPLOYMENT_ENV
-    value: {{ .Values.deploymentEnv }}
-  - name: POSTGRES_BACKGROUND_JOBS_SCHEMA
-    value: pgboss_{{ .Values.chain }}
+  PORT: "3000"
+  NETWORK: {{ .Values.chain }}
+  DEPLOYMENT_ENV: {{ .Values.deploymentEnv }}
+  POSTGRES_BACKGROUND_JOBS_SCHEMA: pgboss_{{ .Values.chain }}

--- a/charts/console-api/templates/deployment-bg-jobs.yaml
+++ b/charts/console-api/templates/deployment-bg-jobs.yaml
@@ -34,16 +34,10 @@ spec:
             - configMapRef:
                 name: {{ .Chart.Name }}-{{ .Values.chain }}-config
           env:
-            - name: PORT
-              value: "3000"
             - name: OTEL_SERVICE_NAME
               value: {{ .Chart.Name }}-{{ .Values.chain }}-bg-jobs
-            - name: NETWORK
-              value: {{ .Values.chain }}
             - name: INTERFACE
               value: "background-jobs"
-            - name: POSTGRES_BACKGROUND_JOBS_SCHEMA
-              value: pgboss_{{ .Values.chain }}
           resources:
             limits:
               cpu: "0.5"

--- a/charts/console-api/templates/deployment.yaml
+++ b/charts/console-api/templates/deployment.yaml
@@ -34,16 +34,10 @@ spec:
             - configMapRef:
                 name: {{ .Chart.Name }}-{{ .Values.chain }}-config
           env:
-            - name: PORT
-              value: "3000"
             - name: OTEL_SERVICE_NAME
               value: {{ .Chart.Name }}-{{ .Values.chain }}
-            - name: NETWORK
-              value: {{ .Values.chain }}
             - name: INTERFACE
               value: "rest"
-            - name: POSTGRES_BACKGROUND_JOBS_SCHEMA
-              value: pgboss_{{ .Values.chain }}
           resources:
             limits:
               cpu: "4"

--- a/charts/console-api/values.yaml
+++ b/charts/console-api/values.yaml
@@ -1,5 +1,8 @@
 appVersion: "2.79.3"
 hostNames:
 
+deploymentEnv: staging
+chain: sandbox
+
 backgroundJobs:
   replicas: 1

--- a/charts/console-web-testnet/Chart.yaml
+++ b/charts/console-web-testnet/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.6.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/console-web-testnet/templates/deployment.yaml
+++ b/charts/console-web-testnet/templates/deployment.yaml
@@ -28,6 +28,8 @@ spec:
           env:
             - name: PORT
               value: "3000"
+            - name: DEPLOYMENT_ENV
+              value: {{ .Values.deploymentEnv }}
           resources:
             limits:
               cpu: "1"

--- a/charts/console-web-testnet/values.yaml
+++ b/charts/console-web-testnet/values.yaml
@@ -1,2 +1,4 @@
 appVersion: "2.46.0"
 hostName: console-beta.akash.network
+deploymentEnv: staging
+chain: testnet

--- a/charts/console-web/Chart.yaml
+++ b/charts/console-web/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.1
+version: 0.5.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/console-web/templates/deployment.yaml
+++ b/charts/console-web/templates/deployment.yaml
@@ -35,6 +35,8 @@ spec:
               value: "3000"
             - name: OTEL_SERVICE_NAME
               value: {{ .Chart.Name }}
+            - name: DEPLOYMENT_ENV
+              value: {{ .Values.deploymentEnv }}
           resources:
             limits:
               cpu: "1"

--- a/charts/indexer/Chart.yaml
+++ b/charts/indexer/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.1.6
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/indexer/Chart.yaml
+++ b/charts/indexer/Chart.yaml
@@ -1,10 +1,6 @@
 apiVersion: v2
 name: indexer
 description: Akash Indexer Helm Chart
-dependencies:
-  - name: nodejs-app
-    version: 0.1.1
-    repository: "file://../nodejs-app"
 
 # A chart can be either an 'application' or a 'library' chart.
 #

--- a/charts/indexer/Chart.yaml
+++ b/charts/indexer/Chart.yaml
@@ -1,6 +1,10 @@
 apiVersion: v2
 name: indexer
 description: Akash Indexer Helm Chart
+dependencies:
+  - name: nodejs-app
+    version: 0.1.1
+    repository: "file://../nodejs-app"
 
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -14,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.1.5
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/indexer/templates/configmap.yaml
+++ b/charts/indexer/templates/configmap.yaml
@@ -4,3 +4,7 @@ metadata:
   name: {{ .Chart.Name }}-{{ .Values.chain }}-config
 data:
 {{ include "app.env" . | indent 2 }}
+  PORT: "3000"
+  OTEL_SERVICE_NAME: {{ .Chart.Name }}-{{ .Values.chain }}
+  DEPLOYMENT_ENV: {{ .Values.deploymentEnv }}
+  NETWORK: {{ .Values.chain }}

--- a/charts/indexer/templates/deployment.yaml
+++ b/charts/indexer/templates/deployment.yaml
@@ -26,15 +26,19 @@ spec:
               name: api-port
               protocol: TCP
           envFrom:
-            - configMapRef:
-                name: {{ .Chart.Name }}-{{ .Values.chain }}-config
             - secretRef:
                 name: {{ .Chart.Name }}-{{ .Values.chain }}-secret
+            - configMapRef:
+                name: {{ .Chart.Name }}-{{ .Values.chain }}-config
           env:
             - name: PORT
               value: "3000"
             - name: OTEL_SERVICE_NAME
               value: {{ .Chart.Name }}-{{ .Values.chain }}
+            - name: DEPLOYMENT_ENV
+              value: {{ .Values.deploymentEnv }}
+            - name: NETWORK
+              value: {{ .Values.chain }}
           resources:
             limits:
               cpu: "4"

--- a/charts/indexer/templates/deployment.yaml
+++ b/charts/indexer/templates/deployment.yaml
@@ -30,15 +30,6 @@ spec:
                 name: {{ .Chart.Name }}-{{ .Values.chain }}-secret
             - configMapRef:
                 name: {{ .Chart.Name }}-{{ .Values.chain }}-config
-          env:
-            - name: PORT
-              value: "3000"
-            - name: OTEL_SERVICE_NAME
-              value: {{ .Chart.Name }}-{{ .Values.chain }}
-            - name: DEPLOYMENT_ENV
-              value: {{ .Values.deploymentEnv }}
-            - name: NETWORK
-              value: {{ .Values.chain }}
           resources:
             limits:
               cpu: "4"

--- a/charts/indexer/values.yaml
+++ b/charts/indexer/values.yaml
@@ -3,3 +3,4 @@ hostNames:
 
 chain: mainnet
 nodePort: 30000
+deploymentEnv: staging

--- a/charts/notifications-testnet/Chart.yaml
+++ b/charts/notifications-testnet/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.1
+version: 1.1.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/notifications-testnet/templates/deployment.yaml
+++ b/charts/notifications-testnet/templates/deployment.yaml
@@ -34,6 +34,10 @@ spec:
               value: "3000"
             - name: INTERFACE
               value: "{{ $interface }}"
+            - name: DEPLOYMENT_ENV
+              value: {{ $.Values.deploymentEnv }}
+            - name: NETWORK
+              value: {{ $.Values.chain }}
           resources:
             limits:
               cpu: "500m"

--- a/charts/notifications-testnet/values.yaml
+++ b/charts/notifications-testnet/values.yaml
@@ -1,1 +1,3 @@
 appVersion: "1.0.0"
+deploymentEnv: staging
+chain: testnet

--- a/charts/notifications/Chart.lock
+++ b/charts/notifications/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: nodejs-app
+  repository: file://../nodejs-app
+  version: 0.1.2
+digest: sha256:5d3ec83c9aa44ffdaf01e8e281ce6fed43c7dc9fd04dff4bb64a12b64ca5e0cb
+generated: "2026-01-15T13:34:40.679426+01:00"

--- a/charts/notifications/Chart.yaml
+++ b/charts/notifications/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.2
+version: 1.1.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/notifications/templates/deployment.yaml
+++ b/charts/notifications/templates/deployment.yaml
@@ -41,6 +41,8 @@ spec:
               value: "{{ $interface }}"
             - name: OTEL_SERVICE_NAME
               value: {{ $.Chart.Name }}-{{ $interface }}
+            - name: DEPLOYMENT_ENV
+              value: {{ $.Values.deploymentEnv }}
           resources:
             limits:
               cpu: "500m"

--- a/charts/notifications/values.yaml
+++ b/charts/notifications/values.yaml
@@ -1,1 +1,4 @@
 appVersion: "1.0.0"
+
+deploymentEnv: staging
+chain: sandbox

--- a/charts/provider-proxy/Chart.yaml
+++ b/charts/provider-proxy/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.1
+version: 0.6.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/provider-proxy/templates/configmap.yaml
+++ b/charts/provider-proxy/templates/configmap.yaml
@@ -4,9 +4,6 @@ metadata:
   name: {{ .Chart.Name }}-{{ .Values.chain }}-config
 data:
 {{ include "app.env" . | indent 2 }}
-  - name: PORT
-    value: "3000"
-  - name: NETWORK
-    value: {{ .Values.chain }}
-  - name: DEPLOYMENT_ENV
-    value: {{ .Values.deploymentEnv }}
+  PORT: "3000"
+  NETWORK: {{ .Values.chain }}
+  DEPLOYMENT_ENV: {{ .Values.deploymentEnv }}

--- a/charts/provider-proxy/templates/configmap.yaml
+++ b/charts/provider-proxy/templates/configmap.yaml
@@ -4,3 +4,9 @@ metadata:
   name: {{ .Chart.Name }}-{{ .Values.chain }}-config
 data:
 {{ include "app.env" . | indent 2 }}
+  - name: PORT
+    value: "3000"
+  - name: NETWORK
+    value: {{ .Values.chain }}
+  - name: DEPLOYMENT_ENV
+    value: {{ .Values.deploymentEnv }}

--- a/charts/provider-proxy/templates/deployment.yaml
+++ b/charts/provider-proxy/templates/deployment.yaml
@@ -30,11 +30,6 @@ spec:
                 name: {{ .Chart.Name }}-{{ .Values.chain }}-secret
             - configMapRef:
                 name: {{ .Chart.Name }}-{{ .Values.chain }}-config
-          env:
-            - name: PORT
-              value: "3000"
-            - name: NETWORK
-              value: {{ .Values.chain }}
           resources:
             limits:
               cpu: "4"

--- a/charts/provider-proxy/values.yaml
+++ b/charts/provider-proxy/values.yaml
@@ -1,3 +1,4 @@
 appVersion: "1.4.3"
 hostNames: []
 chain: sandbox
+deploymentEnv: staging

--- a/charts/stats-web/Chart.yaml
+++ b/charts/stats-web/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/stats-web/templates/configmap.yaml
+++ b/charts/stats-web/templates/configmap.yaml
@@ -7,3 +7,6 @@ data:
   NODE_OPTIONS: >-
     --no-network-family-autoselection
     --enable-source-maps
+  DEPLOYMENT_ENV: {{ .Values.deploymentEnv }}
+  PORT: "3000"
+  OTEL_SERVICE_NAME: {{ .Chart.Name }}

--- a/charts/stats-web/templates/deployment.yaml
+++ b/charts/stats-web/templates/deployment.yaml
@@ -30,11 +30,6 @@ spec:
                 name: {{ .Chart.Name }}-secret
             - configMapRef:
                 name: {{ .Chart.Name }}-config
-          env:
-            - name: PORT
-              value: "3000"
-            - name: OTEL_SERVICE_NAME
-              value: {{ .Chart.Name }}
           resources:
             limits:
               cpu: "1"


### PR DESCRIPTION
## Why

To ensure that services picks the proper .env files, we need to specify `DEPLOYMENT_ENV` env variable