### PR TITLE
Remove duplicated labels error

### DIFF
--- a/charts/akash-provider/templates/service.yaml
+++ b/charts/akash-provider/templates/service.yaml
@@ -5,8 +5,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     akash.network: "true"
-    app.kubernetes.io/name: akash
-    app.kubernetes.io/instance: inventory
     app.kubernetes.io/component: operator
     {{- include "provider.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
Removed failing duplicated labels from service configuration due to already defined in provider.labels.

Helm install failed for release akash-services/akash-services-akash-provider with chart provid er@14.0.5: error while running post render on files: map[string]interface {}(nil): yaml: unmarshal errors:                                                         
  line 13: mapping key "app.kubernetes.io/name" already defined at line 9                                                                                          
  line 14: mapping key "app.kubernetes.io/instance" already defined at line 10