### PR TITLE
feat: expose service version via OTEL

### DIFF
--- a/charts/console-api/Chart.yaml
+++ b/charts/console-api/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.5
+version: 0.7.6
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -23,5 +23,5 @@ appVersion: "2.108.0"
 
 dependencies:
   - name: nodejs-app
-    version: 0.1.1
+    version: 0.1.2
     repository: "file://../nodejs-app"

--- a/charts/console-web/Chart.lock
+++ b/charts/console-web/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: file://../nodejs-app
   version: 0.1.2
 digest: sha256:5d3ec83c9aa44ffdaf01e8e281ce6fed43c7dc9fd04dff4bb64a12b64ca5e0cb
-generated: "2026-01-13T14:39:59.248365+01:00"
+generated: "2026-01-13T14:40:07.952745+01:00"

--- a/charts/console-web/Chart.yaml
+++ b/charts/console-web/Chart.yaml
@@ -14,9 +14,14 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.5.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "2.66.1"
+
+dependencies:
+  - name: nodejs-app
+    version: 0.1.2
+    repository: "file://../nodejs-app"

--- a/charts/console-web/templates/configmap.yaml
+++ b/charts/console-web/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Chart.Name }}-config
+data:
+{{ include "app.env" . | indent 2 }}
+  NODE_OPTIONS: >-
+    --no-network-family-autoselection
+    --enable-source-maps

--- a/charts/console-web/templates/deployment.yaml
+++ b/charts/console-web/templates/deployment.yaml
@@ -25,9 +25,16 @@ spec:
             - containerPort: 3000
               name: api-port
               protocol: TCP
+          envFrom:
+            - secretRef:
+                name: {{ .Chart.Name }}-secret
+            - configMapRef:
+                name: {{ .Chart.Name }}-config
           env:
             - name: PORT
               value: "3000"
+            - name: OTEL_SERVICE_NAME
+              value: {{ .Chart.Name }}
           resources:
             limits:
               cpu: "1"
@@ -43,6 +50,3 @@ spec:
               port: 3000
             initialDelaySeconds: 5
             periodSeconds: 10
-          envFrom:
-            - secretRef:
-                name: {{ .Chart.Name }}-secret

--- a/charts/indexer/Chart.lock
+++ b/charts/indexer/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: file://../nodejs-app
   version: 0.1.2
 digest: sha256:5d3ec83c9aa44ffdaf01e8e281ce6fed43c7dc9fd04dff4bb64a12b64ca5e0cb
-generated: "2026-01-13T14:39:59.248365+01:00"
+generated: "2026-01-13T14:40:13.03318+01:00"

--- a/charts/indexer/Chart.yaml
+++ b/charts/indexer/Chart.yaml
@@ -14,9 +14,14 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "1.12.0"
+
+dependencies:
+  - name: nodejs-app
+    version: 0.1.2
+    repository: "file://../nodejs-app"

--- a/charts/indexer/templates/configmap.yaml
+++ b/charts/indexer/templates/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Chart.Name }}-{{ .Values.chain }}-config
+data:
+{{ include "app.env" . | indent 2 }}

--- a/charts/indexer/templates/deployment.yaml
+++ b/charts/indexer/templates/deployment.yaml
@@ -25,11 +25,14 @@ spec:
             - containerPort: 3000
               name: api-port
               protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ .Chart.Name }}-{{ .Values.chain }}-config
+            - secretRef:
+                name: {{ .Chart.Name }}-{{ .Values.chain }}-secret
           env:
             - name: PORT
               value: "3000"
-            - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "namespace={{ .Release.Namespace }}"
             - name: OTEL_SERVICE_NAME
               value: {{ .Chart.Name }}-{{ .Values.chain }}
           resources:
@@ -41,6 +44,3 @@ spec:
               cpu: "2"
               ephemeral-storage: "1Gi"
               memory: "4Gi"
-          envFrom:
-            - secretRef:
-                name: {{ .Chart.Name }}-{{ .Values.chain }}-secret

--- a/charts/nodejs-app/Chart.yaml
+++ b/charts/nodejs-app/Chart.yaml
@@ -15,4 +15,4 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2

--- a/charts/nodejs-app/templates/_app-env.tpl
+++ b/charts/nodejs-app/templates/_app-env.tpl
@@ -1,5 +1,7 @@
 {{- define "app.env" -}}
-OTEL_RESOURCE_ATTRIBUTES: "namespace={{ .Release.Namespace }}"
+OTEL_RESOURCE_ATTRIBUTES: >-
+  namespace={{ .Release.Namespace }},
+  service.version={{ .Values.appVersion }}
 OTEL_SERVICE_NAME: {{ .Chart.Name | quote }}
 OTEL_NODE_RESOURCE_DETECTORS: "env,host,container,process"
 # --no-network-family-autoselection added because of https://r1ch.net/blog/node-v20-aggregateeerror-etimedout-happy-eyeballs and https://github.com/nodejs/node/issues/54359

--- a/charts/notifications/Chart.yaml
+++ b/charts/notifications/Chart.yaml
@@ -14,9 +14,14 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.1
+version: 1.1.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "1.0.0"
+
+dependencies:
+  - name: nodejs-app
+    version: 0.1.2
+    repository: "file://../nodejs-app"

--- a/charts/notifications/templates/configmap.yaml
+++ b/charts/notifications/templates/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Chart.Name }}-config
+data:
+{{ include "app.env" . | indent 2 }}

--- a/charts/notifications/templates/deployment.yaml
+++ b/charts/notifications/templates/deployment.yaml
@@ -29,11 +29,18 @@ spec:
             - containerPort: 3000
               name: api-port
               protocol: TCP
+          envFrom:
+            - secretRef:
+                name: {{ $.Chart.Name }}-secret
+            - configMapRef:
+                name: {{ $.Chart.Name }}-config
           env:
             - name: PORT
               value: "3000"
             - name: INTERFACE
               value: "{{ $interface }}"
+            - name: OTEL_SERVICE_NAME
+              value: {{ $.Chart.Name }}-{{ $interface }}
           resources:
             limits:
               cpu: "500m"
@@ -55,7 +62,4 @@ spec:
               port: 3000
             initialDelaySeconds: 5
             periodSeconds: 10
-          envFrom:
-            - secretRef:
-                name: {{ $.Chart.Name }}-secret
 {{- end }}

--- a/charts/provider-proxy/Chart.lock
+++ b/charts/provider-proxy/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: nodejs-app
   repository: file://../nodejs-app
-  version: 0.1.1
-digest: sha256:7d5177f8b768103a89646a16575d598973b0d602af0657e4e12332a6ba04a6c3
-generated: "2025-06-18T15:51:42.317859+03:00"
+  version: 0.1.2
+digest: sha256:5d3ec83c9aa44ffdaf01e8e281ce6fed43c7dc9fd04dff4bb64a12b64ca5e0cb
+generated: "2026-01-13T14:40:20.475144+01:00"

--- a/charts/provider-proxy/Chart.yaml
+++ b/charts/provider-proxy/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.6.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -23,5 +23,5 @@ appVersion: "1.13.3"
 
 dependencies:
   - name: nodejs-app
-    version: 0.1.1
+    version: 0.1.2
     repository: "file://../nodejs-app"

--- a/charts/stats-web/Chart.lock
+++ b/charts/stats-web/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: file://../nodejs-app
   version: 0.1.2
 digest: sha256:5d3ec83c9aa44ffdaf01e8e281ce6fed43c7dc9fd04dff4bb64a12b64ca5e0cb
-generated: "2026-01-13T14:39:59.248365+01:00"
+generated: "2026-01-13T14:40:26.33161+01:00"

--- a/charts/stats-web/Chart.yaml
+++ b/charts/stats-web/Chart.yaml
@@ -14,9 +14,14 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "1.0.0"
+
+dependencies:
+  - name: nodejs-app
+    version: 0.1.2
+    repository: "file://../nodejs-app"

--- a/charts/stats-web/templates/configmap.yaml
+++ b/charts/stats-web/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Chart.Name }}-config
+data:
+{{ include "app.env" . | indent 2 }}
+  NODE_OPTIONS: >-
+    --no-network-family-autoselection
+    --enable-source-maps

--- a/charts/stats-web/templates/deployment.yaml
+++ b/charts/stats-web/templates/deployment.yaml
@@ -25,9 +25,16 @@ spec:
             - containerPort: 3000
               name: api-port
               protocol: TCP
+          envFrom:
+            - secretRef:
+                name: {{ .Chart.Name }}-secret
+            - configMapRef:
+                name: {{ .Chart.Name }}-config
           env:
             - name: PORT
               value: "3000"
+            - name: OTEL_SERVICE_NAME
+              value: {{ .Chart.Name }}
           resources:
             limits:
               cpu: "1"
@@ -43,6 +50,3 @@ spec:
               port: 3000
             initialDelaySeconds: 5
             periodSeconds: 10
-          envFrom:
-            - secretRef:
-                name: {{ .Chart.Name }}-secret


### PR DESCRIPTION
## Why

1. Expose service version via otel attributes, so we can see it in grafana
2. unify services NODE_OPTIONS via nodejs-app lib chart

## What

1. exposes service.version via OTEL
2. adds nodejs-app dependency to all console charts
3. because of ^^^ notifications service should have otel enabled