### PR TITLE
feat: increases stack-trace-limit

### DIFF
--- a/charts/console-api/Chart.lock
+++ b/charts/console-api/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: nodejs-app
   repository: file://../nodejs-app
-  version: 0.1.2
-digest: sha256:5d3ec83c9aa44ffdaf01e8e281ce6fed43c7dc9fd04dff4bb64a12b64ca5e0cb
-generated: "2026-01-13T14:39:59.248365+01:00"
+  version: 0.1.3
+digest: sha256:4176d1e82be64b88db21b48bfa72ff1deafe14ce486f4160381cccd402b89c8f
+generated: "2026-01-27T15:21:38.524781+01:00"

--- a/charts/console-api/Chart.yaml
+++ b/charts/console-api/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.7
+version: 0.7.8
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -23,5 +23,5 @@ appVersion: "2.108.0"
 
 dependencies:
   - name: nodejs-app
-    version: 0.1.2
+    version: 0.1.3
     repository: "file://../nodejs-app"

--- a/charts/console-api/templates/configmap.yaml
+++ b/charts/console-api/templates/configmap.yaml
@@ -4,7 +4,5 @@ metadata:
   name: {{ .Chart.Name }}-{{ .Values.chain }}-config
 data:
 {{ include "app.env" . | indent 2 }}
-  PORT: "3000"
   NETWORK: {{ .Values.chain }}
-  DEPLOYMENT_ENV: {{ .Values.deploymentEnv }}
   POSTGRES_BACKGROUND_JOBS_SCHEMA: pgboss_{{ .Values.chain }}

--- a/charts/console-api/values.yaml
+++ b/charts/console-api/values.yaml
@@ -6,3 +6,6 @@ chain: sandbox
 
 backgroundJobs:
   replicas: 1
+
+nodeOptions:
+  enabledOTEL: false

--- a/charts/console-web/Chart.lock
+++ b/charts/console-web/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: nodejs-app
   repository: file://../nodejs-app
-  version: 0.1.2
-digest: sha256:5d3ec83c9aa44ffdaf01e8e281ce6fed43c7dc9fd04dff4bb64a12b64ca5e0cb
-generated: "2026-01-13T14:40:07.952745+01:00"
+  version: 0.1.3
+digest: sha256:4176d1e82be64b88db21b48bfa72ff1deafe14ce486f4160381cccd402b89c8f
+generated: "2026-01-27T15:21:38.851203+01:00"

--- a/charts/console-web/Chart.yaml
+++ b/charts/console-web/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.2
+version: 0.5.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -23,5 +23,5 @@ appVersion: "2.66.1"
 
 dependencies:
   - name: nodejs-app
-    version: 0.1.2
+    version: 0.1.3
     repository: "file://../nodejs-app"

--- a/charts/console-web/templates/configmap.yaml
+++ b/charts/console-web/templates/configmap.yaml
@@ -4,6 +4,3 @@ metadata:
   name: {{ .Chart.Name }}-config
 data:
 {{ include "app.env" . | indent 2 }}
-  NODE_OPTIONS: >-
-    --no-network-family-autoselection
-    --enable-source-maps

--- a/charts/indexer/Chart.lock
+++ b/charts/indexer/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: nodejs-app
   repository: file://../nodejs-app
-  version: 0.1.2
-digest: sha256:5d3ec83c9aa44ffdaf01e8e281ce6fed43c7dc9fd04dff4bb64a12b64ca5e0cb
-generated: "2026-01-13T14:40:13.03318+01:00"
+  version: 0.1.3
+digest: sha256:4176d1e82be64b88db21b48bfa72ff1deafe14ce486f4160381cccd402b89c8f
+generated: "2026-01-27T15:21:39.156145+01:00"

--- a/charts/indexer/Chart.yaml
+++ b/charts/indexer/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.6
+version: 0.1.7
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -23,5 +23,5 @@ appVersion: "1.12.0"
 
 dependencies:
   - name: nodejs-app
-    version: 0.1.2
+    version: 0.1.3
     repository: "file://../nodejs-app"

--- a/charts/indexer/templates/configmap.yaml
+++ b/charts/indexer/templates/configmap.yaml
@@ -4,7 +4,5 @@ metadata:
   name: {{ .Chart.Name }}-{{ .Values.chain }}-config
 data:
 {{ include "app.env" . | indent 2 }}
-  PORT: "3000"
   OTEL_SERVICE_NAME: {{ .Chart.Name }}-{{ .Values.chain }}
-  DEPLOYMENT_ENV: {{ .Values.deploymentEnv }}
   NETWORK: {{ .Values.chain }}

--- a/charts/nodejs-app/Chart.yaml
+++ b/charts/nodejs-app/Chart.yaml
@@ -15,4 +15,4 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3

--- a/charts/nodejs-app/templates/_app-env.tpl
+++ b/charts/nodejs-app/templates/_app-env.tpl
@@ -1,4 +1,6 @@
 {{- define "app.env" -}}
+DEPLOYMENT_ENV: {{ .Values.deploymentEnv }}
+PORT: "3000"
 OTEL_RESOURCE_ATTRIBUTES: >-
   namespace={{ .Release.Namespace }},
   service.version={{ .Values.appVersion }}
@@ -8,5 +10,8 @@ OTEL_NODE_RESOURCE_DETECTORS: "env,host,container,process"
 NODE_OPTIONS: >-
   --no-network-family-autoselection
   --enable-source-maps
+  --stack-trace-limit=25
+{{- if ((.Values.nodeOptions).enabledOTEL) }}
   --require @opentelemetry/auto-instrumentations-node/register
+{{- end }}
 {{- end }}

--- a/charts/notifications/Chart.lock
+++ b/charts/notifications/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: nodejs-app
   repository: file://../nodejs-app
-  version: 0.1.2
-digest: sha256:5d3ec83c9aa44ffdaf01e8e281ce6fed43c7dc9fd04dff4bb64a12b64ca5e0cb
-generated: "2026-01-15T13:34:40.679426+01:00"
+  version: 0.1.3
+digest: sha256:4176d1e82be64b88db21b48bfa72ff1deafe14ce486f4160381cccd402b89c8f
+generated: "2026-01-27T15:21:39.516504+01:00"

--- a/charts/notifications/Chart.yaml
+++ b/charts/notifications/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.3
+version: 1.1.4
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -23,5 +23,5 @@ appVersion: "1.0.0"
 
 dependencies:
   - name: nodejs-app
-    version: 0.1.2
+    version: 0.1.3
     repository: "file://../nodejs-app"

--- a/charts/provider-proxy/Chart.lock
+++ b/charts/provider-proxy/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: nodejs-app
   repository: file://../nodejs-app
-  version: 0.1.2
-digest: sha256:5d3ec83c9aa44ffdaf01e8e281ce6fed43c7dc9fd04dff4bb64a12b64ca5e0cb
-generated: "2026-01-13T14:40:20.475144+01:00"
+  version: 0.1.3
+digest: sha256:4176d1e82be64b88db21b48bfa72ff1deafe14ce486f4160381cccd402b89c8f
+generated: "2026-01-27T15:21:39.852669+01:00"

--- a/charts/provider-proxy/Chart.yaml
+++ b/charts/provider-proxy/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.2
+version: 0.6.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -23,5 +23,5 @@ appVersion: "1.13.3"
 
 dependencies:
   - name: nodejs-app
-    version: 0.1.2
+    version: 0.1.3
     repository: "file://../nodejs-app"

--- a/charts/provider-proxy/templates/configmap.yaml
+++ b/charts/provider-proxy/templates/configmap.yaml
@@ -4,6 +4,4 @@ metadata:
   name: {{ .Chart.Name }}-{{ .Values.chain }}-config
 data:
 {{ include "app.env" . | indent 2 }}
-  PORT: "3000"
   NETWORK: {{ .Values.chain }}
-  DEPLOYMENT_ENV: {{ .Values.deploymentEnv }}

--- a/charts/stats-web/Chart.lock
+++ b/charts/stats-web/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: nodejs-app
   repository: file://../nodejs-app
-  version: 0.1.2
-digest: sha256:5d3ec83c9aa44ffdaf01e8e281ce6fed43c7dc9fd04dff4bb64a12b64ca5e0cb
-generated: "2026-01-13T14:40:26.33161+01:00"
+  version: 0.1.3
+digest: sha256:4176d1e82be64b88db21b48bfa72ff1deafe14ce486f4160381cccd402b89c8f
+generated: "2026-01-27T15:21:40.176762+01:00"

--- a/charts/stats-web/Chart.yaml
+++ b/charts/stats-web/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.1.4
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -23,5 +23,5 @@ appVersion: "1.0.0"
 
 dependencies:
   - name: nodejs-app
-    version: 0.1.2
+    version: 0.1.3
     repository: "file://../nodejs-app"

--- a/charts/stats-web/templates/configmap.yaml
+++ b/charts/stats-web/templates/configmap.yaml
@@ -4,9 +4,4 @@ metadata:
   name: {{ .Chart.Name }}-config
 data:
 {{ include "app.env" . | indent 2 }}
-  NODE_OPTIONS: >-
-    --no-network-family-autoselection
-    --enable-source-maps
-  DEPLOYMENT_ENV: {{ .Values.deploymentEnv }}
-  PORT: "3000"
   OTEL_SERVICE_NAME: {{ .Chart.Name }}


### PR DESCRIPTION
## Why

To have more context when error is thrown

## What

1. increases stack-trace-limit, default value is 10
2. added possibility to configure whether to require OTEL autoinstrumentation using `values.yaml`