### PR TITLE
fix: increases timeouts for api deployments

### DIFF
--- a/charts/console-api/Chart.yaml
+++ b/charts/console-api/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.8
+version: 0.7.9
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/console-api/templates/deployment-bg-jobs.yaml
+++ b/charts/console-api/templates/deployment-bg-jobs.yaml
@@ -53,7 +53,7 @@ spec:
               port: 3000
             initialDelaySeconds: 5
             periodSeconds: 10
-            timeoutSeconds: 5
+            timeoutSeconds: 10
             failureThreshold: 3
           livenessProbe:
             httpGet:
@@ -61,5 +61,5 @@ spec:
               port: 3000
             initialDelaySeconds: 5
             periodSeconds: 10
-            timeoutSeconds: 5
+            timeoutSeconds: 10
             failureThreshold: 3

--- a/charts/console-api/templates/deployment.yaml
+++ b/charts/console-api/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
               port: 3000
             initialDelaySeconds: 5
             periodSeconds: 10
-            timeoutSeconds: 5
+            timeoutSeconds: 10
             failureThreshold: 3
           livenessProbe:
             httpGet:
@@ -61,5 +61,5 @@ spec:
               port: 3000
             initialDelaySeconds: 5
             periodSeconds: 10
-            timeoutSeconds: 5
+            timeoutSeconds: 10
             failureThreshold: 3


### PR DESCRIPTION
## Why

Since we have performance issues, app may start slower. That's why increasing timeouts temporary 