### PR TITLE
feat: adds amplitude proxy in console-web

### DIFF
--- a/charts/console-web/Chart.yaml
+++ b/charts/console-web/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.7.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/console-web/templates/ingress-amplitude.yaml
+++ b/charts/console-web/templates/ingress-amplitude.yaml
@@ -1,0 +1,37 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: "{{ .Chart.Name }}-amplitude-ingress"
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    nginx.ingress.kubernetes.io/upstream-vhost: "api2.amplitude.com"
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    nginx.ingress.kubernetes.io/rewrite-target: /2/httpapi
+    nginx.ingress.kubernetes.io/proxy-ssl-server-name: "on"
+    nginx.ingress.kubernetes.io/proxy-ssl-name: "api2.amplitude.com"
+spec:
+  ingressClassName: nginx
+  tls:
+  - hosts:
+    - "{{ .Values.hostName }}"
+    secretName: console-web-staging-akash-network-tls
+  rules:
+  - host: "{{ .Values.hostName }}"
+    http:
+      paths:
+      - path: /api/collect
+        pathType: Exact
+        backend:
+          service:
+            name: amplitude-external
+            port:
+              number: 443
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: amplitude-external
+  namespace: {{ .Release.Namespace }}
+spec:
+  type: ExternalName
+  externalName: api2.amplitude.com


### PR DESCRIPTION
## Why

Right now, we proxy via application level, nodejs and it's better to do this using infra level and specialized tools like nginx

## What

Adds amplitude proxy ingress in console-web