### PR TITLE
refactor: moves amplitude on a separate subdomain

### DIFF
--- a/charts/console-web/Chart.yaml
+++ b/charts/console-web/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.1
+version: 0.7.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/console-web/templates/ingress-amplitude.yaml
+++ b/charts/console-web/templates/ingress-amplitude.yaml
@@ -1,11 +1,4 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: "{{ .Chart.Name }}-amplitude-proxy-headers"
-  namespace: {{ .Release.Namespace }}
-data:
-  Cookie: ""
----
+
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -17,18 +10,17 @@ metadata:
     nginx.ingress.kubernetes.io/rewrite-target: /2/httpapi
     nginx.ingress.kubernetes.io/proxy-ssl-server-name: "on"
     nginx.ingress.kubernetes.io/proxy-ssl-name: "api2.amplitude.com"
-    nginx.ingress.kubernetes.io/proxy-set-headers: "{{ .Release.Namespace }}/{{ .Chart.Name }}-amplitude-proxy-headers"
 spec:
   ingressClassName: nginx
   tls:
   - hosts:
-    - "{{ .Values.hostName }}"
+    - "console-proxy.akash.network"
     secretName: console-web-staging-akash-network-tls
   rules:
-  - host: "{{ .Values.hostName }}"
+  - host: "console-proxy.akash.network"
     http:
       paths:
-      - path: /api/collect
+      - path: /collect
         pathType: Exact
         backend:
           service:


### PR DESCRIPTION
## Why

To get rid of cookies and extra headers set by sentry when request is sent to amplitude