### PR TITLE
fix(console-api): relax liveness probe and double resources

### DIFF
--- a/charts/console-api/Chart.yaml
+++ b/charts/console-api/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.2
+version: 0.9.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/console-api/templates/deployment.yaml
+++ b/charts/console-api/templates/deployment.yaml
@@ -52,7 +52,7 @@ spec:
             httpGet:
               path: /v1/healthz/liveness
               port: 3000
-            initialDelaySeconds: 5
-            periodSeconds: 10
+            initialDelaySeconds: 30
+            periodSeconds: 15
             timeoutSeconds: 10
-            failureThreshold: 3
+            failureThreshold: 6

--- a/charts/console-api/templates/deployment.yaml
+++ b/charts/console-api/templates/deployment.yaml
@@ -55,4 +55,4 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 10
             timeoutSeconds: 10
-            failureThreshold: 6
+            failureThreshold: 9

--- a/charts/console-api/templates/deployment.yaml
+++ b/charts/console-api/templates/deployment.yaml
@@ -52,7 +52,7 @@ spec:
             httpGet:
               path: /v1/healthz/liveness
               port: 3000
-            initialDelaySeconds: 30
-            periodSeconds: 15
+            initialDelaySeconds: 5
+            periodSeconds: 10
             timeoutSeconds: 10
             failureThreshold: 6

--- a/charts/console-api/values.yaml
+++ b/charts/console-api/values.yaml
@@ -9,24 +9,24 @@ replicas: 2
 resources:
   limits:
     cpu: "8"
-    ephemeral-storage: "4Gi"
-    memory: "16Gi"
+    ephemeral-storage: "2Gi"
+    memory: "8Gi"
   requests:
     cpu: "4"
-    ephemeral-storage: "2Gi"
-    memory: "16Gi"
+    ephemeral-storage: "1Gi"
+    memory: "8Gi"
 
 backgroundJobs:
   replicas: 1
   resources:
     limits:
       cpu: "1"
-      ephemeral-storage: "2Gi"
-      memory: "2Gi"
+      ephemeral-storage: "1Gi"
+      memory: "1Gi"
     requests:
       cpu: "1"
-      ephemeral-storage: "2Gi"
-      memory: "2Gi"
+      ephemeral-storage: "1Gi"
+      memory: "1Gi"
 
 stats:
   replicas: 1

--- a/charts/console-api/values.yaml
+++ b/charts/console-api/values.yaml
@@ -20,11 +20,11 @@ backgroundJobs:
   replicas: 1
   resources:
     limits:
-      cpu: "1"
+      cpu: "0.5"
       ephemeral-storage: "1Gi"
       memory: "1Gi"
     requests:
-      cpu: "1"
+      cpu: "0.5"
       ephemeral-storage: "1Gi"
       memory: "1Gi"
 

--- a/charts/console-api/values.yaml
+++ b/charts/console-api/values.yaml
@@ -8,25 +8,25 @@ replicas: 2
 
 resources:
   limits:
+    cpu: "8"
+    ephemeral-storage: "4Gi"
+    memory: "16Gi"
+  requests:
     cpu: "4"
     ephemeral-storage: "2Gi"
-    memory: "8Gi"
-  requests:
-    cpu: "2"
-    ephemeral-storage: "1Gi"
-    memory: "8Gi"
+    memory: "16Gi"
 
 backgroundJobs:
   replicas: 1
   resources:
     limits:
-      cpu: "0.5"
-      ephemeral-storage: "1Gi"
-      memory: "1Gi"
+      cpu: "1"
+      ephemeral-storage: "2Gi"
+      memory: "2Gi"
     requests:
-      cpu: "0.5"
-      ephemeral-storage: "1Gi"
-      memory: "1Gi"
+      cpu: "1"
+      ephemeral-storage: "2Gi"
+      memory: "2Gi"
 
 stats:
   replicas: 1


### PR DESCRIPTION
## Summary
- Relaxed liveness probe settings to prevent restart loops (initialDelaySeconds 5→30, periodSeconds 10→15, failureThreshold 3→6)
- Doubled console-api resources (CPU 2/4→4/8, memory 8Gi→16Gi)
- Doubled backgroundJobs resources (CPU 0.5→1, memory 1Gi→2Gi)

## Test plan
- [ ] Deploy to staging and verify console-api pods stabilize without restart loops
- [ ] Confirm liveness probe passes consistently under load
- [ ] Verify backgroundJobs pods run without OOM kills