### PR TITLE
chore: console-api reduce default cpu/memory requests/limits

### DIFF
--- a/charts/console-api/Chart.yaml
+++ b/charts/console-api/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.0
+version: 0.10.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/console-api/templates/jobs.yaml
+++ b/charts/console-api/templates/jobs.yaml
@@ -1,4 +1,5 @@
 {{- range .Values.jobs }}
+{{- $job := mergeOverwrite (deepCopy $.Values.jobDefaults) . }}
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -9,28 +10,21 @@ spec:
   schedule: {{ .schedule | quote }}
   jobTemplate:
     spec:
-      failedJobsHistoryLimit: 10
-      successfulJobsHistoryLimit: 0
+      failedJobsHistoryLimit: {{ $job.failedJobsHistoryLimit }}
+      successfulJobsHistoryLimit: {{ $job.successfulJobsHistoryLimit }}
       template:
         metadata:
           labels:
             job: {{ $.Chart.Name }}-{{ $.Values.chain }}-{{ .name }}
         spec:
-          restartPolicy: Never
+          restartPolicy: {{ $job.restartPolicy }}
           containers:
             - name: {{ $.Chart.Name }}-{{ $.Values.chain }}
               image: ghcr.io/akash-network/console-api:{{ $.Values.appVersion }}
               imagePullPolicy: "Always"
               command: {{ .command | toJson }}
               resources:
-                limits:
-                  cpu: "1"
-                  ephemeral-storage: "2Gi"
-                  memory: "1Gi"
-                requests:
-                  cpu: "0.5"
-                  ephemeral-storage: "1Gi"
-                  memory: "512Mi"
+                {{- toYaml $job.resources | nindent 16 }}
               envFrom:
                 - secretRef:
                     name: {{ $.Chart.Name }}-{{ $.Values.chain }}-secret

--- a/charts/console-api/values.yaml
+++ b/charts/console-api/values.yaml
@@ -8,37 +8,51 @@ replicas: 2
 
 resources:
   limits:
-    cpu: "8"
-    ephemeral-storage: "2Gi"
-    memory: "8Gi"
+    cpu: 2
+    ephemeral-storage: 2Gi
+    memory: 4Gi
   requests:
-    cpu: "4"
-    ephemeral-storage: "1Gi"
-    memory: "8Gi"
+    cpu: 250m
+    ephemeral-storage: 1Gi
+    memory: 1Gi
 
 backgroundJobs:
   replicas: 1
   resources:
     limits:
-      cpu: "0.5"
-      ephemeral-storage: "1Gi"
-      memory: "1Gi"
+      cpu: 500m
+      ephemeral-storage: 1Gi
+      memory: 1Gi
     requests:
-      cpu: "0.5"
-      ephemeral-storage: "1Gi"
-      memory: "1Gi"
+      cpu: 50m
+      ephemeral-storage: 1Gi
+      memory: 512Mi
 
 stats:
   replicas: 1
   resources:
     limits:
-      cpu: "0.5"
-      ephemeral-storage: "1Gi"
-      memory: "1Gi"
+      cpu: 500m
+      ephemeral-storage: 1gi
+      memory: 1Gi
     requests:
-      cpu: "0.5"
-      ephemeral-storage: "1Gi"
-      memory: "1Gi"
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 512Mi
 
 nodeOptions:
   enabledOTEL: false
+
+jobDefaults:
+  failedJobsHistoryLimit: 10
+  successfulJobsHistoryLimit: 0
+  restartPolicy: Never
+  resources:
+    limits:
+      cpu: 500m
+      ephemeral-storage: 2Gi
+      memory: 1Gi
+    requests:
+      cpu: 50m
+      ephemeral-storage: 1Gi
+      memory: 256Mi


### PR DESCRIPTION
| Component | | Before | After |
|---|---|---|---|
| **deployment** | cpu.request | 4 | 250m |
| | cpu.limit | 8 | 2 |
| | mem.request | 8Gi | 1Gi |
| | mem.limit | 8Gi | 4Gi |
| **backgroundJobs** | cpu.request | 500m | 50m |
| | cpu.limit | 500m | 500m |
| | mem.request | 1Gi | 512Mi |
| | mem.limit | 1Gi | 1Gi |
| **stats** | cpu.request | 500m | 100m |
| | cpu.limit | 500m | 500m |
| | mem.request | 1Gi | 512Mi |
| | mem.limit | 1Gi | 1Gi |
| **jobDefaults** | cpu.request | 500m | 50m |
| | cpu.limit | 1 | 500m |
| | mem.request | 512Mi | 256Mi |
| | mem.limit | 1Gi | 1Gi |
