### PR TITLE
chore: fix cronjob spec

### DIFF
--- a/charts/console-api/Chart.yaml
+++ b/charts/console-api/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.1
+version: 0.10.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/console-api/templates/jobs.yaml
+++ b/charts/console-api/templates/jobs.yaml
@@ -8,10 +8,10 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 spec:
   schedule: {{ .schedule | quote }}
+  failedJobsHistoryLimit: {{ $job.failedJobsHistoryLimit }}
+  successfulJobsHistoryLimit: {{ $job.successfulJobsHistoryLimit }}
   jobTemplate:
     spec:
-      failedJobsHistoryLimit: {{ $job.failedJobsHistoryLimit }}
-      successfulJobsHistoryLimit: {{ $job.successfulJobsHistoryLimit }}
       template:
         metadata:
           labels:


### PR DESCRIPTION
this pr fixes invalid spec for cronjob

Upgrade to v0.10.1 throws error like:
```
I0319 10:50:05.434198   20420 warnings.go:107] "Warning: unknown field \"spec.jobTemplate.spec.failedJobsHistoryLimit\""
I0319 10:50:05.434269   20420 warnings.go:107] "Warning: unknown field \"spec.jobTemplate.spec.successfulJobsHistoryLimit\""
I0319 10:50:05.549061   20420 warnings.go:107] "Warning: unknown field \"spec.jobTemplate.spec.failedJobsHistoryLimit\""
I0319 10:50:05.549084   20420 warnings.go:107] "Warning: unknown field \"spec.jobTemplate.spec.successfulJobsHistoryLimit\""
I0319 10:50:05.665386   20420 warnings.go:107] "Warning: unknown field \"spec.jobTemplate.spec.failedJobsHistoryLimit\""
I0319 10:50:05.665456   20420 warnings.go:107] "Warning: unknown field \"spec.jobTemplate.spec.successfulJobsHistoryLimit\""
```

It caused by incorrect placement of 
```
failedJobsHistoryLimit: {{ $job.failedJobsHistoryLimit }}
successfulJobsHistoryLimit: {{ $job.successfulJobsHistoryLimit }}
```
which is no available in job spec , but in cronjob spec
see exact cronjob spec here: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/cron-job-v1/