### PR TITLE
fix(operators): honor nodeSelector/tolerations/affinity values

### DIFF
--- a/charts/akash-hostname-operator/Chart.yaml
+++ b/charts/akash-hostname-operator/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
 # Major version bit highlights the mainnet release (e.g. mainnet4 = 4.x.x, mainnet5 = 5.x.x, ...)
-version: 16.0.0-rc0
+version: 16.0.0-rc1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/akash-hostname-operator/templates/deployment.yaml
+++ b/charts/akash-hostname-operator/templates/deployment.yaml
@@ -98,3 +98,15 @@ spec:
                 configMapKeyRef:
                   name: operator-hostname
                   key: gateway-implementation
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/akash-inventory-operator/Chart.yaml
+++ b/charts/akash-inventory-operator/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
 # Major version bit highlights the mainnet release (e.g. mainnet4 = 4.x.x, mainnet5 = 5.x.x, ...)
-version: 16.0.0-rc0
+version: 16.0.0-rc1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/akash-inventory-operator/templates/deployment.yaml
+++ b/charts/akash-inventory-operator/templates/deployment.yaml
@@ -88,3 +88,15 @@ spec:
           configMap:
             name: gpu-validation-script
             defaultMode: 0755
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/akash-inventory-operator/values.yaml
+++ b/charts/akash-inventory-operator/values.yaml
@@ -15,3 +15,9 @@ inventoryConfig:
   exclude:
     nodes: []
     node_storage: []
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
## Problem

The `akash-hostname-operator` and `akash-inventory-operator` charts declare `nodeSelector` / `tolerations` / `affinity` values but the `templates/deployment.yaml` in both charts never references those values, so they are silently ignored.

This prevents operators from scheduling on clusters where every non-control-plane node is tainted (for example a single ingress-only worker tainted `akash.network/role=ingress:NoSchedule`) — there is no way to make Helm emit a toleration onto the pod spec.

## Fix

Adds the standard `with` / `toYaml` blocks at the bottom of `spec.template.spec` in both Deployment templates, matching the pattern already used in `akash-provider/templates/statefulset.yaml:346-357`:

```yaml
      {{- with .Values.nodeSelector }}
      nodeSelector:
        {{- toYaml . | nindent 8 }}
      {{- end }}
      {{- with .Values.affinity }}
      affinity:
        {{- toYaml . | nindent 8 }}
      {{- end }}
      {{- with .Values.tolerations }}
      tolerations:
        {{- toYaml . | nindent 8 }}
      {{- end }}
```

Also adds the three keys to `akash-inventory-operator/values.yaml`, which were previously missing entirely (only `akash-hostname-operator/values.yaml` had them declared).

## Backward compatibility

Empty values render no blocks — existing users see no behavior change. Verified with `helm template` against both charts with and without overrides, and `helm lint` passes on both.