### PR TITLE
fix(notifications): distinguish workloads by unique container name

### DIFF
--- a/charts/notifications/Chart.yaml
+++ b/charts/notifications/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.5
+version: 1.3.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/notifications/templates/deployment.yaml
+++ b/charts/notifications/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         app: {{ $.Chart.Name }}-{{ $interface }}
     spec:
       containers:
-        - name: {{ $.Chart.Name }}
+        - name: {{ $.Chart.Name }}-{{ $interface }}
           image: "ghcr.io/akash-network/notifications:{{ $.Values.appVersion }}"
           imagePullPolicy: "Always"
           ports:


### PR DESCRIPTION
## Summary
- Sets the container name to `{{ $.Chart.Name }}-{{ $interface }}` so each of the four notifications workloads (`rest`, `chain-events`, `alert-events`, `notifications-events`) has a distinct container name matching its Deployment.
- Container-scoped alerts, dashboards, and log/metric queries can now identify which workload fired without a secondary lookup.
- Bumps chart version 1.2.5 → 1.3.0.

Closes [CON-249](https://linear.app/akash-network/issue/CON-249/notifications-workloads-are-indistinguishable-in-container-scoped).

## Test plan
- [x] `helm lint charts/notifications`
- [x] `helm template test charts/notifications` — each Deployment renders with a unique container name
- [ ] After deploy: confirm a per-workload restart alert surfaces the specific workload name