### PR TITLE
fix: uses only migrations secret for migration hook

### DIFF
--- a/charts/provider-inventory/Chart.yaml
+++ b/charts/provider-inventory/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/provider-inventory/templates/job-migrations.yaml
+++ b/charts/provider-inventory/templates/job-migrations.yaml
@@ -24,8 +24,6 @@ spec:
           command: {{ .Values.migrations.command | toJson }}
           envFrom:
             - secretRef:
-                name: {{ .Chart.Name }}-{{ .Values.chain }}-secret
-            - secretRef:
                 name: {{ .Chart.Name }}-{{ .Values.chain }}-migrations-secret
           env:
             - name: NETWORK


### PR DESCRIPTION
## Why

Migrator is restricted and should not have access to all same secrets, only to the database