### PR TITLE
fix: adds libuv threads config to provider-inventory sync

### DIFF
--- a/charts/provider-inventory/Chart.yaml
+++ b/charts/provider-inventory/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.1.4
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/provider-inventory/templates/deployment-providers-sync.yaml
+++ b/charts/provider-inventory/templates/deployment-providers-sync.yaml
@@ -37,6 +37,11 @@ spec:
               value: {{ .Chart.Name }}-{{ .Values.chain }}-providers-sync
             - name: INTERFACE
               value: "providers-sync"
+              # see comment for details https://github.com/nodejs/node/issues/22468#issuecomment-416795256
+              # usually it's recommended to set this variable to number of CPU cores,
+              # but in case of provider inventory we can have a lot of idle time while waiting for messages from providers, so we can benefit from having more threads in the pool
+            - name: UV_THREADPOOL_SIZE
+              value: 64
           resources:
             {{- toYaml .Values.providersSync.resources | nindent 12 }}
           readinessProbe:


### PR DESCRIPTION
## Why

During cold start, the service created too many TCP connections at once. This caused request queuing, and provider stream requests were aborted before receiving the first message due to the “first message not received within timeout” guard.