### PR TITLE
fix: quote UV_THREADPOOL_SIZE env value in provider-inventory sync

### DIFF
--- a/charts/provider-inventory/Chart.yaml
+++ b/charts/provider-inventory/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.1.5
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/provider-inventory/templates/deployment-providers-sync.yaml
+++ b/charts/provider-inventory/templates/deployment-providers-sync.yaml
@@ -41,7 +41,7 @@ spec:
               # usually it's recommended to set this variable to number of CPU cores,
               # but in case of provider inventory we can have a lot of idle time while waiting for messages from providers, so we can benefit from having more threads in the pool
             - name: UV_THREADPOOL_SIZE
-              value: 64
+              value: "64"
           resources:
             {{- toYaml .Values.providersSync.resources | nindent 12 }}
           readinessProbe:


### PR DESCRIPTION
## Why

Deploying `provider-inventory` (chart `0.1.4`) fails during `helm upgrade` with:

```
cannot patch "provider-inventory-sandbox-providers-sync" with kind Deployment:
json: cannot unmarshal number into Go struct field
EnvVar.spec.template.spec.containers.env.value of type string
```

The libuv threads config added in #573 set `UV_THREADPOOL_SIZE` with an unquoted value (`64`), which YAML parses as an integer. Kubernetes requires container env var `value` fields to be **strings**, so the rendered Deployment patch is rejected and the release rolls back.

Only the `providers-sync` Deployment carries this env var, which is why that's the resource the patch failed on.

## What

- Quote the env value: `value: 64` → `value: "64"` in `deployment-providers-sync.yaml`.
- Bump chart version `0.1.4` → `0.1.5` so the fix ships as a new release (the broken `0.1.4` is already published).

🤖 Generated with [Claude Code](https://claude.com/claude-code)