### PR TITLE
provider: configure confidential initdata and storage classes

### DIFF
--- a/charts/akash-provider/Chart.yaml
+++ b/charts/akash-provider/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
 # Major version bit highlights the mainnet release (e.g. mainnet4 = 4.x.x, mainnet5 = 5.x.x, ...)
-version: 19.0.1
+version: 19.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/akash-provider/Chart.yaml
+++ b/charts/akash-provider/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
 # Major version bit highlights the mainnet release (e.g. mainnet4 = 4.x.x, mainnet5 = 5.x.x, ...)
-version: 19.0.2
+version: 19.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/akash-provider/scripts/run.sh
+++ b/charts/akash-provider/scripts/run.sh
@@ -18,14 +18,15 @@ type bc || exit 1
 
 # Build provider-services run command with optional certificate issuer flags
 PROVIDER_CMD="/usr/bin/provider-services run"
+CC_ARGS=()
 
 # These are public, operator-controlled inputs. Tenant key material remains a
 # sealed SDL value and is never mounted into the Provider pod.
 if [[ -n "${AP_CC_KBS_URL:-}" ]]; then
-    PROVIDER_CMD="${PROVIDER_CMD} --cc-kbs-url=${AP_CC_KBS_URL}"
-    PROVIDER_CMD="${PROVIDER_CMD} --cc-kbs-cert-file=${AP_CC_KBS_CERT_FILE}"
-    PROVIDER_CMD="${PROVIDER_CMD} --cc-image-security-policy-uri=${AP_CC_IMAGE_SECURITY_POLICY_URI}"
-    PROVIDER_CMD="${PROVIDER_CMD} --cc-agent-policy-file=${AP_CC_AGENT_POLICY_FILE}"
+    CC_ARGS+=("--cc-kbs-url=${AP_CC_KBS_URL}")
+    CC_ARGS+=("--cc-kbs-cert-file=${AP_CC_KBS_CERT_FILE}")
+    CC_ARGS+=("--cc-image-security-policy-uri=${AP_CC_IMAGE_SECURITY_POLICY_URI}")
+    CC_ARGS+=("--cc-agent-policy-file=${AP_CC_AGENT_POLICY_FILE}")
 fi
 
 # Add certificate issuer flags if enabled (HTTP challenge default, DNS providers optional)
@@ -56,7 +57,9 @@ echo "AP_CERT_ISSUER_EMAIL: ${AP_CERT_ISSUER_EMAIL}"
 echo "AP_CERT_ISSUER_CA_DIR_URL: ${AP_CERT_ISSUER_CA_DIR_URL}"
 echo "AP_CERT_ISSUER_DNS_PROVIDERS: ${AP_CERT_ISSUER_DNS_PROVIDERS}"
 echo "AP_CERT_ISSUER_HTTP_CHALLENGE_PORT: ${AP_CERT_ISSUER_HTTP_CHALLENGE_PORT}"
-echo "Final command: ${PROVIDER_CMD}"
+printf 'Final command: %s' "${PROVIDER_CMD}"
+printf ' %q' "${CC_ARGS[@]}"
+printf '\n'
 echo "=============================="
 
 # Start provider-services and monitor its output
@@ -73,4 +76,4 @@ if [[ $run_debug == "true" ]]; then
     fi
 fi
 
-${runcmd}
+${runcmd} "${CC_ARGS[@]}"

--- a/charts/akash-provider/scripts/run.sh
+++ b/charts/akash-provider/scripts/run.sh
@@ -19,6 +19,15 @@ type bc || exit 1
 # Build provider-services run command with optional certificate issuer flags
 PROVIDER_CMD="/usr/bin/provider-services run"
 
+# These are public, operator-controlled inputs. Tenant key material remains a
+# sealed SDL value and is never mounted into the Provider pod.
+if [[ -n "${AP_CC_KBS_URL:-}" ]]; then
+    PROVIDER_CMD="${PROVIDER_CMD} --cc-kbs-url=${AP_CC_KBS_URL}"
+    PROVIDER_CMD="${PROVIDER_CMD} --cc-kbs-cert-file=${AP_CC_KBS_CERT_FILE}"
+    PROVIDER_CMD="${PROVIDER_CMD} --cc-image-security-policy-uri=${AP_CC_IMAGE_SECURITY_POLICY_URI}"
+    PROVIDER_CMD="${PROVIDER_CMD} --cc-agent-policy-file=${AP_CC_AGENT_POLICY_FILE}"
+fi
+
 # Add certificate issuer flags if enabled (HTTP challenge default, DNS providers optional)
 if [[ "${AP_CERT_ISSUER_ENABLED}" == "true" ]]; then
     PROVIDER_CMD="${PROVIDER_CMD} --cert-issuer-enabled=true"

--- a/charts/akash-provider/templates/configmap-cc-initdata.yaml
+++ b/charts/akash-provider/templates/configmap-cc-initdata.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.confidentialCompute.initdata.enabled }}
+{{- $certificate := required "confidentialCompute.initdata.kbsCertificate is required when initdata is enabled" .Values.confidentialCompute.initdata.kbsCertificate }}
+{{- $agentPolicy := required "confidentialCompute.initdata.agentPolicy is required when initdata is enabled" .Values.confidentialCompute.initdata.agentPolicy }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "provider.fullname" . }}-cc-initdata
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "provider.fullname" . }}
+    {{- include "provider.labels" . | nindent 4 }}
+data:
+  kbs-ca.pem: |
+    {{- $certificate | nindent 4 }}
+  agent-policy.rego: |
+    {{- $agentPolicy | nindent 4 }}
+{{- end }}

--- a/charts/akash-provider/templates/configmap-main.yaml
+++ b/charts/akash-provider/templates/configmap-main.yaml
@@ -1,3 +1,6 @@
+{{- if and (not .Values.confidentialCompute.initdata.enabled) .Values.confidentialCompute.persistentStorageClasses }}
+{{- fail "confidentialCompute.initdata must be enabled when persistentStorageClasses is non-empty" }}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -94,4 +97,8 @@ data:
   AP_CC_KBS_CERT_FILE: "/etc/akash/cc-initdata/kbs-ca.pem"
   AP_CC_IMAGE_SECURITY_POLICY_URI: {{ required "confidentialCompute.initdata.imageSecurityPolicyURI is required when initdata is enabled" .Values.confidentialCompute.initdata.imageSecurityPolicyURI | quote }}
   AP_CC_AGENT_POLICY_FILE: "/etc/akash/cc-initdata/agent-policy.rego"
+  {{- end }}
+  {{- with .Values.confidentialCompute.persistentStorageClasses }}
+  # Space-delimited for Viper's string-slice environment parsing.
+  AP_CC_PERSISTENT_STORAGE_CLASSES: {{ join " " . | quote }}
   {{- end }}

--- a/charts/akash-provider/templates/configmap-main.yaml
+++ b/charts/akash-provider/templates/configmap-main.yaml
@@ -88,4 +88,10 @@ data:
   AKASH_ATTESTATION_SIDECAR_IMAGE: "{{ .Values.attestation.sidecarImage.repository }}:{{ .Values.attestation.sidecarImage.tag | default .Chart.AppVersion }}"
   AKASH_ATTESTATION_WEBHOOK_PORT: "{{ .Values.attestation.webhookPort | default 9443 }}"
   {{- end }}
-
+  {{- if .Values.confidentialCompute.initdata.enabled }}
+  # Public inputs for measured confidential-compute initdata.
+  AP_CC_KBS_URL: {{ required "confidentialCompute.initdata.kbsURL is required when initdata is enabled" .Values.confidentialCompute.initdata.kbsURL | quote }}
+  AP_CC_KBS_CERT_FILE: "/etc/akash/cc-initdata/kbs-ca.pem"
+  AP_CC_IMAGE_SECURITY_POLICY_URI: {{ required "confidentialCompute.initdata.imageSecurityPolicyURI is required when initdata is enabled" .Values.confidentialCompute.initdata.imageSecurityPolicyURI | quote }}
+  AP_CC_AGENT_POLICY_FILE: "/etc/akash/cc-initdata/agent-policy.rego"
+  {{- end }}

--- a/charts/akash-provider/templates/statefulset.yaml
+++ b/charts/akash-provider/templates/statefulset.yaml
@@ -31,6 +31,9 @@ spec:
     metadata:
       annotations:
         checksum/cm-scripts: {{ include (print $.Template.BasePath "/configmap-scripts.yaml") . | sha256sum }}
+        {{- if .Values.confidentialCompute.initdata.enabled }}
+        checksum/cm-cc-initdata: {{ include (print $.Template.BasePath "/configmap-cc-initdata.yaml") . | sha256sum }}
+        {{- end }}
       labels:
         app: {{ include "provider.fullname" . }}
         {{- include "provider.selectorLabels" . | nindent 8 }}
@@ -319,6 +322,11 @@ spec:
               mountPath: /config
             - name: home
               mountPath: "{{ .Values.home }}"
+            {{- if .Values.confidentialCompute.initdata.enabled }}
+            - name: cc-initdata
+              mountPath: /etc/akash/cc-initdata
+              readOnly: true
+            {{- end }}
             {{- if and .Values.letsEncrypt.providers.googleCloud (index .Values.letsEncrypt.providers.googleCloud "enabled" | default false) }}
             - name: gcp-service-account
               mountPath: /etc/gcp
@@ -339,6 +347,11 @@ spec:
         - name: home
           persistentVolumeClaim:
             claimName: {{ include "provider.fullname" . }}-home
+        {{- if .Values.confidentialCompute.initdata.enabled }}
+        - name: cc-initdata
+          configMap:
+            name: {{ include "provider.fullname" . }}-cc-initdata
+        {{- end }}
         {{- if and .Values.letsEncrypt.providers.googleCloud (index .Values.letsEncrypt.providers.googleCloud "enabled" | default false) }}
         - name: gcp-service-account
           secret:

--- a/charts/akash-provider/values.yaml
+++ b/charts/akash-provider/values.yaml
@@ -129,6 +129,9 @@ attestation:
 # This must never contain a volume DEK, a tenant signing key, or a KBS
 # administrator credential.
 confidentialCompute:
+  # Block storage classes qualified by the operator for confidential
+  # persistent storage. An empty list disables the feature.
+  persistentStorageClasses: []
   initdata:
     enabled: false
     # HTTPS KBS origin, with no path, query, credentials, or fragment.

--- a/charts/akash-provider/values.yaml
+++ b/charts/akash-provider/values.yaml
@@ -124,6 +124,22 @@ attestation:
     # with the provider image tag.
     tag: ""
 
+# Public configuration used to construct measured Kata initdata for workloads
+# with sealed environment values or tenant-signed persistent-volume keyRefs.
+# This must never contain a volume DEK, a tenant signing key, or a KBS
+# administrator credential.
+confidentialCompute:
+  initdata:
+    enabled: false
+    # HTTPS KBS origin, with no path, query, credentials, or fragment.
+    kbsURL: ""
+    # Public KBS certificate chain containing one to five PEM certificates.
+    kbsCertificate: ""
+    # Content-addressed kbs:/// image-security-policy resource URI.
+    imageSecurityPolicyURI: ""
+    # Kata agent policy measured into each confidential guest.
+    agentPolicy: ""
+
 #  monitor
 ##
 


### PR DESCRIPTION
## Why

The Provider needs supported chart inputs for measured Trustee configuration and an operator-owned allowlist of Block storage classes qualified for confidential persistence.

## What changed

- bump the Provider chart to `19.0.3`
- add opt-in `confidentialCompute.initdata` public values
- require all public inputs when initdata is enabled
- store the public KBS certificate chain and Kata agent policy in a read-only ConfigMap
- pass the public KBS URL, certificate path, image policy URI, and agent policy path to Provider
- add `confidentialCompute.persistentStorageClasses`
- keep an empty allowlist disabled
- reject a non-empty storage allowlist unless measured initdata is enabled
- roll the StatefulSet when public initdata changes

The chart never accepts or mounts a tenant DEK, tenant signing key, registry credential, or KBS administrator token.

## Dependency

This PR depends on akash-network/provider#427 or a later release containing the corresponding flags. The current chart `appVersion: 0.16.1` does not understand the feature and this chart must not ship independently.

## Validation

- default lint and render pass without confidential resources or allowlist environment
- enabled lint and render pass with all public inputs and two storage classes
- the allowlist renders exactly as Viper's space-delimited string slice
- an allowlist without measured initdata fails rendering
- incomplete initdata fails rendering
- ShellCheck and Helm GitHub checks pass
- `git diff --check` passes

No chart package, image, tag, or release was published.